### PR TITLE
Eliminar string MongoDB

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ var port          = 8080;
 var ipaddress     = "172.30.84.32";
 
 
-var mongoURL = "mongodb://admin:password123@ds125862.mlab.com:25862/fraternidadwash";
+var mongoURL = process.env.MDB;
 
 
 


### PR DESCRIPTION
Se elimina uso de string MongoDB con credenciales funcionales, recomendable usar .env para almacenar datos críticos, más aun considerando que el proyecto es publico.

http://prntscr.com/kkrmw3